### PR TITLE
docs: add AGENTS.md for Cursor Cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product overview
+
+Single Next.js portfolio site (Pages Router). No backend, database, or Docker. All content is static/bundled from `data/*.js`.
+
+### Services
+
+| Service | Command | Port | Required? |
+|---------|---------|------|-----------|
+| Next.js dev server | `npm run dev` | 3000 | Yes (local development) |
+
+Only one process is needed. Use a tmux session for long-running dev servers.
+
+### Standard commands
+
+See `package.json` scripts and `README.md`:
+
+- **Install:** `npm install` (repo has `package-lock.json`; README mentions Yarn but either works)
+- **Dev:** `npm run dev` → http://localhost:3000
+- **Lint:** `npm run lint`
+- **Build:** `npm run build`
+- **Prod server:** `npm run start` (run after `npm run build`)
+
+### Runtime requirements
+
+- **Node.js:** >= 18.18 (Next.js 15 requirement). Node 20+ LTS recommended.
+- **No environment variables** are required for local dev. PWA is disabled in dev (`next.config.js`).
+
+### Gotchas
+
+- `npm run build` regenerates `public/sw.js` (PWA service worker). Do not commit this file unless intentionally updating PWA assets.
+- CI workflow (`.github/workflows/lint.yml`) still pins Node 14.x, which is incompatible with Next 15; local/Cloud Agent setup should use Node 18+.
+- `next.config.js` logs a warning about unrecognized `pwa` key — harmless, from `next-pwa` integration.
+- No automated tests are configured in this repo; verify changes manually in the browser (sections, i18n EN/PT toggle, theme toggle).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific instructions for developing this Next.js portfolio locally.

## Contents
- Service overview (single Next.js dev server on port 3000)
- Standard commands (`npm install`, `npm run dev`, lint, build)
- Runtime requirements (Node >= 18.18)
- Gotchas (PWA `sw.js` regeneration, stale CI Node version, no automated tests)

## Environment verification
The development environment was verified on this branch:
- `npm install` — 719 packages installed
- `npm run lint` — passed
- `npm run build` — passed (static pages generated)
- `npm run dev` — serving at http://localhost:3000
- Manual browser test: sections scroll, EN/PT language toggle, dark/light theme toggle all working

[portfolio-dev-demo.mp4](https://cursor.com/agents/bc-0cb816e9-08a6-44f5-8c4d-b5513a61f0cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio-dev-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cb816e9-08a6-44f5-8c4d-b5513a61f0cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cb816e9-08a6-44f5-8c4d-b5513a61f0cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

